### PR TITLE
删除一些没有引用的包

### DIFF
--- a/src/main/java/com/zvidia/pomelo/protobuf/Encoder.java
+++ b/src/main/java/com/zvidia/pomelo/protobuf/Encoder.java
@@ -2,7 +2,6 @@ package com.zvidia.pomelo.protobuf;
 
 import com.zvidia.pomelo.exception.PomeloException;
 import com.zvidia.pomelo.utils.StringUtils;
-import com.zvidia.pomelo.exception.PomeloException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -10,7 +9,6 @@ import org.omg.CORBA.PRIVATE_MEMBER;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Set;
 


### PR DESCRIPTION
android 的虚拟机是基于 java 6 实现的..

而 Encoder 引用了一个不使用的类...但是java 6 没有的类
import java.nio.charset.StandardCharsets;

我觉得还是尽量避免吧....
