### PR TITLE
front-end can't decode protobuf message with type int32 when encoded bytes'length is more than 1 byte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/
 .project
 .class
 .jar
+*.swp

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zvidia</groupId>
     <artifactId>pomelo</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0-websocket</version>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/zvidia/pomelo/protobuf/Codec.java
+++ b/src/main/java/com/zvidia/pomelo/protobuf/Codec.java
@@ -16,7 +16,18 @@ public class Codec {
     }
 
     public static int decodeUInt32(byte[] bytes) {
-        return ByteUtils.bytesToInt(bytes);
+		int result = 0;
+		for(int i=0; i<bytes.length; i++)
+		{
+			byte tmp = bytes[i];
+			result += (tmp & 0x7f) << 7 * i;
+			if(tmp > 0)
+			{
+				return result;
+			}
+		}
+
+		return result;
     }
 
     public static byte[] encodeSInt32(int num) {
@@ -24,7 +35,10 @@ public class Codec {
     }
 
     public static int decodeSInt32(byte[] bytes) {
-        return ByteUtils.bytesToInt(bytes);
+		int uResult = Codec.decodeUInt32(bytes);
+		int flag = ((uResult % 2) == 1 ) ? -1 : 1;
+
+		return ((uResult % 2 + uResult)/2) * flag;
     }
 
     public static byte[] encodeUInt64(long num) {

--- a/src/main/java/com/zvidia/pomelo/protobuf/Decoder.java
+++ b/src/main/java/com/zvidia/pomelo/protobuf/Decoder.java
@@ -127,12 +127,12 @@ public class Decoder {
                 return Codec.decodeSInt32(getBytes(false));// & 0xff;
             }
             case _float: {
-                float aFloat = buffer.getFloat(offset);
+                float aFloat = buffer.getFloat();
                 offset += 4;
                 return aFloat;
             }
             case _double: {
-                double aDouble = buffer.getDouble(offset);
+                double aDouble = buffer.getDouble();
                 offset += 8;
                 return aDouble;
             }

--- a/src/main/java/com/zvidia/pomelo/protobuf/Decoder.java
+++ b/src/main/java/com/zvidia/pomelo/protobuf/Decoder.java
@@ -124,7 +124,7 @@ public class Decoder {
             }
             case _int32:
             case _sInt32: {
-                return getByte() & 0xff;
+                return Codec.decodeSInt32(getBytes(false));// & 0xff;
             }
             case _float: {
                 float aFloat = buffer.getFloat(offset);
@@ -184,12 +184,16 @@ public class Decoder {
     }
 
     private byte[] getBytes(boolean flag) {
-        ByteBuffer buf = ByteBuffer.allocate(4);
+        ByteBuffer buf = ByteBuffer.allocate(5);
         int pos = offset;
         flag = flag || false;
-        int b = buffer.getInt(pos);
-        buf.putInt(b);
-        pos += 4;
+		byte b; 
+		do{
+			b = buffer.get();
+			buf.put(b);
+			pos += 1;
+		}while(b<0);
+
         if (!flag) {
             offset = pos;
             buffer.position(pos);


### PR DESCRIPTION
"connector.entryHandler.enter": {
        "required int32 code": 1,
        "optional double serverTime": 2,
        "optional string session": 3
    }
and we act like this:    next(null, {code: 200,session:'aaabbbb'});
the 200 can't be resolved corrected;
